### PR TITLE
Fixed paths for vehicle_unflipping addon

### DIFF
--- a/addons/vehicle_unflipping/$PBOPREFIX$
+++ b/addons/vehicle_unflipping/$PBOPREFIX$
@@ -1,1 +1,1 @@
-z\aet_aux\addons\vehicle_unflipping
+z\aet\addons\vehicle_unflipping

--- a/addons/vehicle_unflipping/CfgEventHandlers.hpp
+++ b/addons/vehicle_unflipping/CfgEventHandlers.hpp
@@ -3,14 +3,14 @@ class Extended_PostInit_EventHandlers
 {
     class vet_unflipping
     {
-        serverInit = "call compile preprocessFileLineNumbers 'z\aet_aux\addons\vehicle_unflipping\XEH_postInitServer.sqf'";
-        clientInit = "call compile preprocessFileLineNumbers 'z\aet_aux\addons\vehicle_unflipping\XEH_postInitClient.sqf'";
+        serverInit = "call compile preprocessFileLineNumbers 'z\aet\addons\vehicle_unflipping\XEH_postInitServer.sqf'";
+        clientInit = "call compile preprocessFileLineNumbers 'z\aet\addons\vehicle_unflipping\XEH_postInitClient.sqf'";
     };
 };
 class Extended_PreInit_EventHandlers
 {
     class vet_unflipping
     {
-        init = "call compile preprocessFileLineNumbers 'z\aet_aux\addons\vehicle_unflipping\XEH_preInit.sqf'";
+        init = "call compile preprocessFileLineNumbers 'z\aet\addons\vehicle_unflipping\XEH_preInit.sqf'";
     };
 };

--- a/addons/vehicle_unflipping/CfgFunctions.hpp
+++ b/addons/vehicle_unflipping/CfgFunctions.hpp
@@ -5,7 +5,7 @@ class CfgFunctions
     {
         class functions
         {
-            file = "z\aet_aux\addons\vehicle_unflipping\functions";
+            file = "z\aet\addons\vehicle_unflipping\functions";
 
             class addUnflipActionLocal {};
             class canUnflipLocal {};
@@ -19,7 +19,7 @@ class CfgFunctions
 
         class debug
         {
-            file = "z\aet_aux\addons\vehicle_unflipping\functions\debug";
+            file = "z\aet\addons\vehicle_unflipping\functions\debug";
 
             class debug {};
         };

--- a/addons/vehicle_unflipping/script_component.hpp
+++ b/addons/vehicle_unflipping/script_component.hpp
@@ -4,5 +4,5 @@
 #define COMPONENT_BEAUTIFIED Vehicle Unflipping
 
 
-#include "\z\aet_aux\addons\main\script_mod.hpp"
-#include "\z\aet_aux\addons\main\script_macros.hpp"
+#include "\z\aet\addons\main\script_mod.hpp"
+#include "\z\aet\addons\main\script_macros.hpp"


### PR DESCRIPTION
- Updated paths in vehicle_unflipping addon to use aet instead of aet_aux.