### PR TITLE
Create addon sog_modifications for SOGPF modifications

### DIFF
--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -1,7 +1,7 @@
 #define MAJOR 1
 #define MINOR 12
 #define PATCH 0
-#define BUILD 203
+#define BUILD 207
 
 
 // #define VERSION MACROS

--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -1,7 +1,7 @@
 #define MAJOR 1
 #define MINOR 12
 #define PATCH 0
-#define BUILD 207
+#define BUILD 208
 
 
 // #define VERSION MACROS

--- a/addons/sog_modifications/$PBOPREFIX$
+++ b/addons/sog_modifications/$PBOPREFIX$
@@ -1,1 +1,1 @@
-z\aet_aux\addons\sog_modifications
+z\aet\addons\sog_modifications

--- a/addons/sog_modifications/$PBOPREFIX$
+++ b/addons/sog_modifications/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\aet_aux\addons\sog_modifications

--- a/addons/sog_modifications/CfgFunctions.hpp
+++ b/addons/sog_modifications/CfgFunctions.hpp
@@ -1,6 +1,6 @@
 // class CfgFunctions
 // {
-//     class SOG_MODIFICATIONS
+//     class ADDON
 //     {
 //         class COMPONENT
 //         {

--- a/addons/sog_modifications/CfgFunctions.hpp
+++ b/addons/sog_modifications/CfgFunctions.hpp
@@ -1,0 +1,14 @@
+// class CfgFunctions
+// {
+//     class SOG_MODIFICATIONS
+//     {
+//         class COMPONENT
+//         {
+
+//             file = PATH_TO_FUNC;
+
+//             class example { postInit = 1; };
+
+//         };
+//     };
+// };

--- a/addons/sog_modifications/CfgMagazines.hpp
+++ b/addons/sog_modifications/CfgMagazines.hpp
@@ -1,0 +1,3 @@
+class CfgMagazines {
+    #include "CfgMagazines\belts.hpp"
+};

--- a/addons/sog_modifications/CfgMagazines/belts.hpp
+++ b/addons/sog_modifications/CfgMagazines/belts.hpp
@@ -1,0 +1,16 @@
+class vn_mg42_50_mag;
+class vn_mg42_50_t_mag;
+
+class sog_modifications_mg42_100_mag: vn_mg42_50_mag {
+    count = 100;
+    mass = 60;
+    descriptionShort = "100Rnd. MG42 Drum. <br />Calibre: 7.92x57mm. <br />Used in MG42 machine gun";
+    displayName = "100Rnd. MG42 Drum";
+};
+
+class sog_modifications_mg42_100_t_mag: vn_mg42_50_t_mag {
+    count = 100;
+    mass = 60;
+    descriptionShort = "100Rnd. MG42 Tracer Drum. <br />Calibre: 7.92x57mm. <br />Used in MG42 machine gun";
+    displayName = "100Rnd. MG42 Drum (Tracer)";
+};

--- a/addons/sog_modifications/CfgWeapons.hpp
+++ b/addons/sog_modifications/CfgWeapons.hpp
@@ -1,0 +1,3 @@
+class CfgWeapons {
+	#include "CfgWeapons\weapons.hpp"
+};

--- a/addons/sog_modifications/CfgWeapons/weapons.hpp
+++ b/addons/sog_modifications/CfgWeapons/weapons.hpp
@@ -1,0 +1,5 @@
+class vn_lmg;
+
+class vn_mg42: vn_lmg {
+	magazines[] += {"sog_modifications_mg42_100_mag", "sog_modifications_mg42_100_t_mag"};
+};	

--- a/addons/sog_modifications/XEH/CfgXEH.hpp
+++ b/addons/sog_modifications/XEH/CfgXEH.hpp
@@ -1,6 +1,6 @@
 // No need to change anything here
 class Extended_PreInit_EventHandlers {
-    class SOG_MODIFICATIONS {
+    class ADDON {
         init = QUOTE(call COMPILE_FILE(XEH\XEH_preInit));
     };
 };

--- a/addons/sog_modifications/XEH/CfgXEH.hpp
+++ b/addons/sog_modifications/XEH/CfgXEH.hpp
@@ -1,0 +1,6 @@
+// No need to change anything here
+class Extended_PreInit_EventHandlers {
+    class SOG_MODIFICATIONS {
+        init = QUOTE(call COMPILE_FILE(XEH\XEH_preInit));
+    };
+};

--- a/addons/sog_modifications/XEH/XEH_preInit.sqf
+++ b/addons/sog_modifications/XEH/XEH_preInit.sqf
@@ -1,0 +1,17 @@
+#include "../script_component.hpp"
+
+
+/*	here, you put in your CBA Settings so they are available in the editor!
+[
+	
+	QSET(displayMusic),					//    _setting     - Unique setting name. Matches resulting variable name <STRING>
+	"CHECKBOX",								//    _settingType - Type of setting. Can be "CHECKBOX", "EDITBOX", "LIST", "SLIDER" or "COLOR" <STRING>
+	["Display Music Title","This enables the message of the currently played music title by the CVO Music System"],
+											//    _title       - Display name or display name + tooltip (optional, default: same as setting name) <STRING, ARRAY>
+	["AET", "AET Music"],					//    _category    - Category for the settings menu + optional sub-category <STRING, ARRAY>
+	false,									//    _valueInfo   - Extra properties of the setting depending of _settingType. See examples below <ANY>
+	0,										//    _isGlobal    - 1: all clients share the same setting, 2: setting can't be overwritten (optional, default: 0) <NUMBER>
+	{},										//    _script      - Script to execute when setting is changed. (optional) <CODE>
+	false									//    _needRestart - Setting will be marked as needing mission restart after being changed. (optional, default false) <BOOL>
+] call CBA_fnc_addSetting;
+*/

--- a/addons/sog_modifications/config.cpp
+++ b/addons/sog_modifications/config.cpp
@@ -6,10 +6,10 @@ class CfgPatches {
         // Meta information for editor
 		name = ADDON_NAME;
 
-        author = "$STR_aet_aux_author";
+        author = "$STR_aet_author";
         authors[] = {"Nomas / Redwan S. [AET]", "OverlordZorn [CVO]"};
         
-        url = "$STR_aet_aux_URL";
+        url = "$STR_aet_URL";
 
 		VERSION_CONFIG;
 

--- a/addons/sog_modifications/config.cpp
+++ b/addons/sog_modifications/config.cpp
@@ -1,0 +1,41 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+	class SOG_MODIFICATIONS {
+
+        // Meta information for editor
+		name = ADDON_NAME;
+
+        author = "$STR_aet_aux_author";
+        authors[] = {"Nomas / Redwan S. [AET]", "OverlordZorn [CVO]"};
+        
+        url = "$STR_aet_aux_URL";
+
+		VERSION_CONFIG;
+
+        // Addon Specific Information
+        // Minimum compatible version. When the game's version is lower, pop-up warning will appear when launching the game.
+        requiredVersion = 2.02;
+
+        // Required addons, used for setting load order.
+        // When any of the addons is missing, pop-up warning will appear when launching the game.
+        requiredAddons[] = {QPVAR(main),"cba_main","weapons_f_vietnam_04_c"};
+
+		// Optional. If this is 1, if any of requiredAddons[] entry is missing in your game the entire config will be ignored and return no error (but in rpt) so useful to make a compat Mod (Since Arma 3 2.14)
+		skipWhenMissingDependencies = 1;
+        
+        // List of objects (CfgVehicles classes) contained in the addon. Important also for Zeus content (units and groups)
+        units[] = {};
+
+        // List of weapons (CfgWeapons classes) contained in the addon.
+        weapons[] = {};
+
+	};
+};
+
+#include "CfgFunctions.hpp"
+#include "XEH\CfgXEH.hpp"
+
+
+#include "CfgMagazines.hpp"
+#include "CfgWeapons.hpp"

--- a/addons/sog_modifications/config.cpp
+++ b/addons/sog_modifications/config.cpp
@@ -1,14 +1,14 @@
 #include "script_component.hpp"
 
 class CfgPatches {
-	class SOG_MODIFICATIONS {
+	class ADDON {
 
         // Meta information for editor
 		name = ADDON_NAME;
 
         author = "$STR_aet_author";
-        authors[] = {"Nomas / Redwan S. [AET]", "OverlordZorn [CVO]"};
-        
+        authors[] = {"Nomas / Redwan S. [AET]", "Esmeray [AET]"};
+
         url = "$STR_aet_URL";
 
 		VERSION_CONFIG;

--- a/addons/sog_modifications/script_component.hpp
+++ b/addons/sog_modifications/script_component.hpp
@@ -4,5 +4,5 @@
 #define COMPONENT_BEAUTIFIED SOG Modifications
 
 
-#include "\z\aet_aux\addons\main\script_mod.hpp"
-#include "\z\aet_aux\addons\main\script_macros.hpp"
+#include "\z\aet\addons\main\script_mod.hpp"
+#include "\z\aet\addons\main\script_macros.hpp"

--- a/addons/sog_modifications/script_component.hpp
+++ b/addons/sog_modifications/script_component.hpp
@@ -1,0 +1,8 @@
+#define COMPONENT sog_modifications
+
+// This is being used for the Addon's Name and can be "My Addon Template Framework"
+#define COMPONENT_BEAUTIFIED SOG Modifications
+
+
+#include "\z\aet_aux\addons\main\script_mod.hpp"
+#include "\z\aet_aux\addons\main\script_macros.hpp"


### PR DESCRIPTION
See title.

Currently the addon adds 100-round drum magazines for MG42 by inheriting from SOGPF's 50-round drum magazines and modifying required values.

Tested locally, no issues found.