### PR TITLE
Stop logged admin from getting disclaimer

### DIFF
--- a/addons/disclaimer/functions/fn_postInit.sqf
+++ b/addons/disclaimer/functions/fn_postInit.sqf
@@ -20,7 +20,7 @@ Example:
 
 
 private _code = {
-	private _cond = hasInterface && { SET(enabled) && { !( SET(disable_in_editor) && { is3DENPreview } ) }};
+	private _cond = hasInterface && { SET(enabled) && { !( SET(disable_in_editor) && { is3DENPreview } ) && { (call BIS_fnc_admin) isEqualTo 0 }}};
 	
 	if _cond then { 
 		[QGVAR(EH_request), ["REQUEST", player]] call CBA_fnc_serverEvent; 

--- a/addons/disclaimer/functions/fn_postInit.sqf
+++ b/addons/disclaimer/functions/fn_postInit.sqf
@@ -20,7 +20,7 @@ Example:
 
 
 private _code = {
-	private _cond = hasInterface && { SET(enabled) && { !( SET(disable_in_editor) && { is3DENPreview } ) && { (call BIS_fnc_admin) isEqualTo 0 }}};
+	private _cond = hasInterface && { SET(enabled) && { !( SET(disable_in_editor) && { is3DENPreview } ) && { !( IS_ADMIN )}}};
 	
 	if _cond then { 
 		[QGVAR(EH_request), ["REQUEST", player]] call CBA_fnc_serverEvent; 


### PR DESCRIPTION
Admin that is logged in will not recieve the disclaimer, to facilitate server side QA or other times where you have to load the mission multiple times.
Lazy eval is continued here, and even if it is mistakenly evaled it returns 0 anyways on localhost, so not an issue.