### PR TITLE
Update `fn_lockAISeats.sqf` of `common` addon

### DIFF
--- a/addons/common/functions/ai/fn_lockAISeats.sqf
+++ b/addons/common/functions/ai/fn_lockAISeats.sqf
@@ -40,7 +40,7 @@ private _crew = fullCrew [_vehicle, "", !_lockState];
 			case ("cargo"): {_vehicle lockCargo [_x # 2, _lockState]};
 			case ("commander");
 			case ("turret");
-			case ("gunner"); {_vehicle lockTurret [_x # 3, _lockState]};
+			case ("gunner"): {_vehicle lockTurret [_x # 3, _lockState]};
 		};
 	};
 } forEach _crew;

--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -1,6 +1,6 @@
 #define MAJOR 2
 #define MINOR 4
-#define PATCH 2
+#define PATCH 3
 #define BUILD 666
 
 


### PR DESCRIPTION
- Fixed switch that checks for seats, it was broken due to using `;` instead of `:` resulting in final condition not firing.